### PR TITLE
Support multi-line parentheses comments

### DIFF
--- a/grammars/forth.cson
+++ b/grammars/forth.cson
@@ -44,8 +44,9 @@
         'name': 'comment.block.documentation.forth'
       }
       {
+        'begin': '(?<=^|\\s)\\(\\s'
         'comment': 'ANSI line comment'
-        'match': '(?<=^|\\s)(\\.?\\( [^)]*\\))'
+        'end': '\\)'
         'name': 'comment.line.parentheses.forth'
       }
     ]


### PR DESCRIPTION
Currently only comments on a single line are highlighted correctly:
```
( x -- x )
```

This PR enables comments to be highlighted correctly when spanning multiple lines too:
```
(
  This is also a valid comment
)
```