### PR TITLE
Fix highlighting of ; word

### DIFF
--- a/grammars/forth.cson
+++ b/grammars/forth.cson
@@ -166,7 +166,7 @@
         'name': 'keyword.other.compile-only.forth'
       '4':
         'name': 'keyword.other.word.forth'
-    'end': '(;(?i:CODE)?)'
+    'end': '(?<=^|\\s)(;(?i:CODE)?)(?=\\s)'
     'endCaptures':
       '0':
         'name': 'keyword.other.compile-only.forth'


### PR DESCRIPTION
The `;` word that ends colon-definitions is a normal word and should be delimited by a whitespaces  before being highlighted.

Currently these 2 cases are highlighted incorrectly:
```
: foo x;
: bar y ;z
```
The words `x;` and `;z` are technically valid and do not end the definition. This PR stops highlighting the `;` in these cases.