### PR TITLE
Add loop index K

### DIFF
--- a/grammars/forth.cson
+++ b/grammars/forth.cson
@@ -112,7 +112,7 @@
   'variable':
     'patterns': [
       {
-        'match': '\\b(?i:I|J)\\b'
+        'match': '\\b(?i:I|J|K)\\b'
         'name': 'variable.language.forth'
       }
     ]


### PR DESCRIPTION
Similar to the already supported `I` and `J`, there is a 3rd level index `K` available.